### PR TITLE
fix: added package to handle normalization (works as polyfill, so it can work on IE11)

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,9 +1,10 @@
 import simplePinyin from 'simple-pinyin'
 import getSlug from 'speakingurl'
+import unorm from 'unorm'
 
 function removeDiacritics(str) {
   // eslint-disable-next-line
-  return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+  return unorm.nfd(str).replace(/[\u0300-\u036f]/g, '')
 }
 
 export default function slugify(str, options = {}) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "ember-auto-import": "^1.2.19",
     "ember-cli-babel": "^7.1.2",
     "simple-pinyin": "^3.0.2",
-    "speakingurl": "^14.0.1"
+    "speakingurl": "^14.0.1",
+    "unorm": "^1.5.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9238,6 +9238,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+unorm@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.5.0.tgz#01fa9b76f1c60f7916834605c032aa8962c3f00a"
+  integrity sha512-sMfSWoiRaXXeDZSXC+YRZ23H4xchQpwxjpw1tmfR+kgbBCaOgln4NI0LXejJIhnBuKINrB3WRn+ZI8IWssirVw==
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"


### PR DESCRIPTION
Here is the package added.
https://github.com/walling/unorm

close #3 