### PR TITLE
Feat/ Implement js functions as template helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ ember install ember-slugify
 
 ## Usage
 
+### In a `js` file
+
 ```js
 import slugify, { removeDiacritics } from 'ember-slugify';
 
@@ -35,6 +37,15 @@ let slug = slugify('你好你怎么样 monsieur', options); // ni#hao#ni#zen#me#
 let noDiacritics = removeDiacritics('Théâtre'); // Theatre
 let slug = slugify('Théâtre'); // theatre
 ```
+
+### In a template
+
+```hbs
+await render(hbs`{{slugify '你好你怎么样 monsieur'}}`)
+await render(hbs`{{remove-diacritics 'Théâtre'}}`)
+```
+
+The separator option is not available on `slugify` helper.
 
 ## Contributing
 

--- a/addon/helpers/remove-diacritics.js
+++ b/addon/helpers/remove-diacritics.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper'
+import { removeDiacritics as removeDiacriticsFunction } from 'ember-slugify'
+
+function removeDiacritics(args) {
+  let [string] = args
+  return removeDiacriticsFunction(string)
+}
+
+export default helper(removeDiacritics)

--- a/addon/helpers/slugify.js
+++ b/addon/helpers/slugify.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper'
+import { slugify as slugfyFunction } from 'ember-slugify'
+
+function slugify(args) {
+  let [string] = args
+  return slugfyFunction(string)
+}
+
+export default helper(slugify)

--- a/app/helpers/remove-diacritics.js
+++ b/app/helpers/remove-diacritics.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-slugify/helpers/remove-diacritics'

--- a/app/helpers/slugify.js
+++ b/app/helpers/slugify.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-slugify/helpers/slugify'

--- a/tests/integration/helpers/remove-diacritics-test.js
+++ b/tests/integration/helpers/remove-diacritics-test.js
@@ -1,0 +1,16 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+module('Integration | Helper | remove-diacritics', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it removes diacritics', async function(assert) {
+    await render(hbs`{{remove-diacritics ''}}`)
+    assert.equal(this.element.textContent.trim(), '')
+    await render(hbs`{{remove-diacritics 'é è à ù ç č Ž ñ'}}`)
+    assert.equal(this.element.textContent.trim(), 'e e a u c c Z n')
+  })
+
+})

--- a/tests/integration/helpers/slugify-test.js
+++ b/tests/integration/helpers/slugify-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+module('Integration | Helper | slugify', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it slugifies', async function(assert) {
+    await render(hbs`{{slugify ''}}`)
+    assert.equal(this.element.textContent.trim(), '')
+    await render(hbs`{{slugify 'bonjour'}}`)
+    assert.equal(this.element.textContent.trim(), 'bonjour')
+    await render(hbs`{{slugify 'annyǒng hashimnikka'}}`)
+    assert.equal(this.element.textContent.trim(), 'annyong-hashimnikka')
+    await render(hbs`{{slugify 'Bon jOuR Töi 1337   '}}`)
+    assert.equal(this.element.textContent.trim(), 'bon-jour-toi-1337')
+  })
+
+})


### PR DESCRIPTION
## Features
### Implement js functions as template helpers (#48) 

`slugify` and `removeDiatrics` functions can now be called as template helpers: 

```hbs
await render(hbs`{{slugify '你好你怎么样 monsieur'}}`)
await render(hbs`{{remove-diacritics 'Théâtre'}}`)
```