### PR TITLE
doc: add CI and other badges in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ember-slugify
 
-[![CircleCI](https://circleci.com/gh/peopledoc/ember-slugify.svg?style=shield&circle-token=106b80d7153b94e6ee96541d1647d8e3984862cd)](https://circleci.com/gh/peopledoc/ember-slugify)
+[![CI](https://github.com/peopledoc/ember-slugify/actions/workflows/ci.yml/badge.svg)](https://github.com/peopledoc/ember-slugify/actions/workflows/ci.yml) [![Ember Observer Score](https://emberobserver.com/badges/ember-slugify.svg)](https://emberobserver.com/addons/ember-slugify)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Library to slugify your strings within Ember.
 


### PR DESCRIPTION
## Doc

- Add CI badge in the README (#123)
- Add Ember Observer Score badge in the README (#123)
- Add License badge in the README (#123)