### PR TITLE
CI - Stop testing for Ember.js beta and canary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@
 #$   - scenario: ember-lts-3.16
 #$   - scenario: ember-lts-3.20
 #$   - scenario: ember-release
-#$   - scenario: ember-beta
 #$   - scenario: ember-canary
 #$   - scenario: ember-default-with-jquery
 #$   - scenario: ember-classic
@@ -175,7 +174,6 @@ jobs:
           ember-lts-3.16,
           ember-lts-3.20,
           ember-release,
-          ember-beta,
           ember-canary,
           ember-default-with-jquery,
           ember-classic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       with:
         fetch-depth: 1
 
-    - uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
         node-version: '${{ env.NODE_VERSION }}'
 
@@ -89,7 +89,7 @@ jobs:
       with:
         fetch-depth: 1
 
-    - uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
         node-version: '${{ env.NODE_VERSION }}'
 
@@ -134,7 +134,7 @@ jobs:
       with:
         fetch-depth: 1
 
-    - uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
         node-version: '${{ env.NODE_VERSION }}'
 
@@ -182,7 +182,7 @@ jobs:
       with:
         fetch-depth: 1
 
-    - uses: actions/setup-node@v2-beta
+    - uses: actions/setup-node@v2
       with:
         node-version: '${{ env.NODE_VERSION }}'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,16 +59,12 @@ jobs:
         path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
-          hashFiles('**/yarn.lock'
-          ) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Lint
       run: yarn lint
@@ -104,16 +100,12 @@ jobs:
         path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
-          hashFiles('**/yarn.lock'
-          ) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       run: yarn test:ember --launch ${{ matrix.browser }}
@@ -150,8 +142,7 @@ jobs:
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
         key: ${{ runner.os }}-${{ matrix.node-version }}-floating-deps
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-
+        restore-keys: ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --no-lockfile --non-interactive
@@ -169,13 +160,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ember-try-scenario: [
-          ember-lts-3.16,
-          ember-lts-3.20,
-          ember-release,
-          ember-default-with-jquery,
-          ember-classic
-        ]
+        ember-try-scenario:
+          - ember-lts-3.16
+          - ember-lts-3.20
+          - ember-release
+          - ember-default-with-jquery
+          - ember-classic
 
     steps:
     - uses: actions/checkout@v2
@@ -197,16 +187,12 @@ jobs:
         path: |
           ${{ steps.global-cache-dir-path.outputs.dir }}
           node_modules
-        key: ${{ runner.os }}-${{ matrix.node-version }}-${{
-          hashFiles('**/yarn.lock'
-          ) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ matrix.node-version }}-
+        key: ${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: ${{ runner.os }}-${{ matrix.node-version }}-
 
     - name: Install Dependencies
       run: yarn install --frozen-lockfile
-      if: |
-        steps.cache-dependencies.outputs.cache-hit != 'true'
+      if: steps.cache-dependencies.outputs.cache-hit != 'true'
 
     - name: Test
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@
 #$   - scenario: ember-lts-3.16
 #$   - scenario: ember-lts-3.20
 #$   - scenario: ember-release
-#$   - scenario: ember-canary
 #$   - scenario: ember-default-with-jquery
 #$   - scenario: ember-classic
 #$ nodeVersion: '12'
@@ -174,7 +173,6 @@ jobs:
           ember-lts-3.16,
           ember-lts-3.20,
           ember-release,
-          ember-canary,
           ember-default-with-jquery,
           ember-classic
         ]

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -31,14 +31,6 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-beta',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('beta'),
-          },
-        },
-      },
-      {
         name: 'ember-canary',
         npm: {
           devDependencies: {

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -31,14 +31,6 @@ module.exports = async function () {
         },
       },
       {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
-      {
         name: 'ember-default-with-jquery',
         env: {
           EMBER_OPTIONAL_FEATURES: JSON.stringify({


### PR DESCRIPTION
## CI

### Stop testing for Ember.js beta and canary (#141)

### Use GitHub Action `actions/setup-node@v2` (#141)

