### PR TITLE
build: release v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-slugify",
   "description": "Library to slugify your strings within Ember.",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "license": "MIT",
   "author": {
     "name": "PeopleDoc",


### PR DESCRIPTION
## Breaking changes

#### Drop Ember 3.12 support (#113)

#### Drop Node <= 10.* (#116)

`ember-auto-import` 2.x requires Node >= 12.

#### `ember-auto-import` 2.x (#116)

> addons that upgrade to ember-auto-import >= 2 will only work in apps that have `ember-auto-import`
>  >= 2, so they should do their own semver major releases when they upgrade

See [upgrade guide 1.x to 2.x](https://github.com/ef4/ember-auto-import/blob/master/docs/upgrade-guide-2.0.md)


#### Update to ember 3.28 (#142)


## Build

#### Bump `eslint` from 6.8.0 to 7.9.0 (#51)
#### Bump `@ember/optional-features` from 1.3.0 to 2.0.0 (#52)
#### Bump `ember-resolver` from 8.0.0 to 8.0.2 (#53)
#### Bump `eslint-config-peopledoc` from 2.0.1 to 2.0.2 (#54)
#### Bump `qunit-dom` from 1.2.0 to 1.5.0 (#55)
#### Bump `@ember/optional-features` from 1.3.0 to 2.0.0 (#58)
#### Bump `eslint-plugin-ember` from 8.14.0 to 9.3.0 (#57)
#### Bump `ember-load-initializers` from 2.1.1 to 2.1.2 (#62)
#### Bump `eslint` from 7.11.0 to 7.14.0 (#64)
#### Bump `qunit-dom` from 1.5.0 to 1.6.0 (#66)
#### Bump `@glimmer/tracking` from 1.0.2 to 1.0.3 (#67)
#### Bump `eslint-plugin-ember` from 9.3.0 to 10.1.1 (#69)
#### Bump `ember-template-lint` from 2.14.0 to 2.15.0 (#70)
#### Bump `@glimmer/component` from 1.0.2 to 1.0.3 (#71)
#### Bump `ember-source` from 3.20.5 to 3.24.1 (#73)
#### Bump `eslint` from 7.14.0 to 7.18.0 (#74)
#### Bump `ember-source-channel-url` from 2.0.1 to 3.0.0 (#76)
#### Bump `ember-template-lint` from 2.15.0 to 2.17.0 (#77)
#### Bump `eslint-plugin-ember` from 10.1.1 to 10.1.2 (#78)
#### Bump `eslint` from 7.18.0 to 7.19.0 (#79)
#### Bump `eslint` from 7.19.0 to 7.20.0 (#83)
#### Bump `eslint-plugin-ember` from 10.1.2 to 10.2.0 (#84)
#### Bump `ember-template-lint` from 2.17.0 to 2.19.0 (#85)
#### Bump `ember-template-lint` from 2.19.0 to 2.20.0 (#86)
#### Bump `ember-template-lint` from 2.20.0 to 2.21.0 (#87)
#### Bump `ember-source` from 3.24.1 to 3.25.3 (#88)
#### Bump `eslint` from 7.20.0 to 7.22.0 (#92)
#### Bump `eslint-plugin-ember` from 10.2.0 to 10.3.0 (#96)
#### Bump `@glimmer/component` from 1.0.3 to 1.0.4 (#97)
#### Bump `@glimmer/tracking` from 1.0.3 to 1.0.4 (#98)
#### Bump `ember-source` from 3.25.3 to 3.26.1 (#99)
#### Bump `ember-template-lint` from 3.1.1 to 3.2.0 (#100)
#### Bump `eslint-plugin-ember` from 10.3.0 to 10.4.1 (#102)
#### Bump `ember-template-lint` from 3.2.0 to 3.3.1 (#104)
#### Bump `eslint` from 7.22.0 to 7.25.0 (#105)
#### Bump `ember-source` from 3.26.1 to 3.27.2 (#111)
#### Bump `eslint-plugin-ember` from 10.4.1 to 10.5.0 (#114)
#### Bump `ember-source` from 3.27.2 to 3.27.3 (#115)
#### Bump `eslint` from 7.27.0 to 7.28.0 (#117)
#### Bump `ember-template-lint` from 2.21.0 to 3.5.0 (#119)
#### Bump `qunit` from 2.15.0 to 2.16.0 (#120)
#### Bump `eslint` from 7.28.0 to 7.29.0 (#121)
#### Bump `prettier` from 2.3.0 to 2.3.2 (#124)
#### Bump `ember-cli-inject-live-reload` from 2.0.2 to 2.1.0 (
#### Bump `webpack` from 5.38.1 to 5.42.0 (#126)
#### Bump `@ember/test-helpers` from 2.2.6 to 2.2.8 (#127)
#### Bump `webpack` from 5.42.0 to 5.44.0 (#128)
#### Bump `eslint-plugin-ember` from 10.5.0 to 10.5.1 (#129)
#### Bump `webpack` from 5.44.0 to 5.47.1 (#132)
#### Bump `@ember/test-helpers` from 2.2.8 to 2.2.9 (#133)
#### Bump `ember-template-lint` from 3.5.0 to 3.5.1 (#134)
#### Bump `@ember/test-helpers` from 2.2.9 to 2.4.0 (#135)
#### Bump `webpack` from 5.47.1 to 5.50.0 (#136)
#### Bump `eslint` from 7.29.0 to 7.32.0 (#137)
#### Bump `qunit-dom` from 1.6.0 to 2.0.0 (#145)
#### Bump `eslint-plugin-qunit` from 6.2.0 to 7.0.0 (#143)
#### Bump `eslint-plugin-prettier` from 3.4.1 to 4.0.0 (#147)
#### Bump `ember-cli-htmlbars` from 4.3.1 to 5.3.1 (#45)
#### Bump `ember-auto-import` from 1.6.0 to 1.7.0 (#63)
#### Bump `ini` from 1.3.5 to 1.3.7 (#65)
#### Bump `socket.io` from 2.3.0 to 2.4.1 (#75)
#### Bump `ember-cli-babel` from 7.23.0 to 7.23.1 (#80)
#### Bump `ember-auto-import` from 1.7.0 to 1.10.1 (#81)
#### Bump `ember-cli-htmlbars` from 5.3.1 to 5.3.2 (#82)
#### Bump `ember-cli-htmlbars` from 5.3.2 to 5.6.4 (#89)
#### Bump `elliptic` from 6.5.3 to 6.5.4 (#90)
#### Bump `ember-cli-babel` from 7.23.1 to 7.26.2 (#93)
#### Bump `ember-cli-htmlbars` from 5.6.4 to 5.7.1 (#94)
#### Bump `ember-auto-import` from 1.10.1 to 1.11.2 (#95)
#### Bump `ssri` from 6.0.1 to 6.0.2 (#101)
#### Bump `ember-auto-import` from 1.11.2 to 1.11.3 (#103)
#### Bump `underscore` from 1.11.0 to 1.13.1 (#106)
#### Bump `hosted-git-info` from 2.8.8 to 2.8.9 (#109)
#### Bump `handlebars` from 4.7.6 to 4.7.7 (#108)
#### Bump `ws` from 7.4.2 to 7.4.6 (#112)
#### Bump `tmpl` from 1.0.4 to 1.0.5 (#140)
#### Bump `ember-cli-htmlbars` from 5.7.1 to 6.0.0 (#148)

#### Upgrade dependencies to Ember 3.20 (#56)

#### Upgrade `ember-template-lint@3.1.1` (#91)

### Update to ember 3.24 (LTS) (#113)

#### Force `clean-css` to v4.2.1 (#116)

As previous versions have a vulnerability that is not manage by Ember 3.24.

#### Patch `ember-qunit` to 5.1.4 (#116)

#### Update `simple-pinyin` to v4 (#142)

#### Update `ember-cli` to version 3.28.3 (#149)

#### Update `@embroider/test-setup` to v0.47.1 (#149)


## Chores

#### Update lint config of HBS files (#91)

#### Set @peopledoc/tribe-js as code owner (#150)

#### Refine information in `package.json` (#151)

#### Add contributors to README (#153)


## CI

#### Update CircleCI config + update orb `circleci/node@2.1.1` (#56)

#### Update orb `circleci/node@4.5.0` (#113)

#### Move to GitHub Actions (#122)

Use Github Actions instead of CircleCI.

#### Stop testing for Ember.js beta and canary (#141)

#### Use GitHub Action `actions/setup-node@v2` (#141)

#### Reuse organisation's workflow to run lint & tests (#149)

This change also activates the tests for Embroider.

#### Reuse organisation's workflow to run tag & publish (#149)


## Documentation

#### Add status badges to the README (#123)

- Add CI badge in the README
- Add Ember Observer Score badge in the README
- Add License badge in the README
