### PR TITLE
fix(ci): fix release tests suite

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -26,6 +26,9 @@ module.exports = async function () {
       {
         name: 'ember-release',
         npm: {
+          dependencies: {
+            'ember-auto-import': '^2.0.0',
+          },
           devDependencies: {
             'ember-source': await getChannelURL('release'),
           },


### PR DESCRIPTION
## CI

### Fix release tests suite (#168)

Define ember-auto-import v2 as deps for the ember-release ember-try configuration.